### PR TITLE
Support for Elasticsearch 5.1

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -2,7 +2,7 @@ const elasticsearch = require('elasticsearch')
 const connectionClass = require('http-aws-es')
 
 // This should match the version of ELasticsearch used
-const API_VERSION = '1.5'
+const API_VERSION = '5.0'
 
 function createClient (url) {
   const region = url.match(/\.(\w{2}-\w{4}-\d)\.es\./).pop()

--- a/tools/uuids.js
+++ b/tools/uuids.js
@@ -12,14 +12,17 @@ function fetchScan () {
   return client.search({
     index: options.index,
     type: 'item',
-    search_type: 'scan',
     sort: [ '_doc' ],
     scroll: '1m',
-    size: 1000,
+    size: 10000,
     _source: false
   })
     .then((response) => {
       status.total = response.hits.total
+
+      response.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
+      status.tick(response.hits.hits.length)
+
       return response._scroll_id
     })
 }
@@ -30,13 +33,10 @@ function fetchScroll (scrollId) {
     scrollId
   })
     .then((response) => {
-      const uuids = response.hits.hits.map((item) => item._id).join('\n')
-
-      output.write(uuids + '\n')
-
+      response.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
       status.tick(response.hits.hits.length)
 
-      if (!status.complete) {
+      if (response.hits.hits.length > 0) {
         return fetchScroll(response._scroll_id)
       } else {
         output.end()


### PR DESCRIPTION
* `scan` search type no longer exists, sorting by _doc is as good apparently
* Increase the batch size