### PR TITLE
fix: update Elastisearch API version number

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -3,7 +3,7 @@ const elasticsearch = require('elasticsearch')
 const credentials = require('./aws-credentials')
 
 // This should match the version of ELasticsearch used
-const API_VERSION = '5.1'
+const API_VERSION = '5.6'
 
 const REGION = /\.(\w{2}-\w{4}-\d)\.es\./
 


### PR DESCRIPTION
Addresses the changes merge in #62.

See https://github.com/elastic/elasticsearch-js/issues/511#issuecomment-461620157.