### PR TITLE
Use non-browsers CircleCI Docker Node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node14: &container_config_node14
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:14-browsers
+      - image: circleci/node:14
 
   workspace_root: &workspace_root
     ~/project


### PR DESCRIPTION
Ref. https://hub.docker.com/r/circleci/node

`node:<version>`
> This is the defacto image. If you are unsure about what your needs are, you probably want to use this one for common tools.

`node:<version>-browsers`
> This image makes browser testing easier. It extends the defacto image and installs Firefox and Chrome/chromedriver and configure them to run in a chrontainzied environment

This repo does not require the latter image so this PR changes it to the former, avoiding the unnecessary installation and configuration that happens with the latter.