### PR TITLE
Switch to Elasticsearch v7 cluster

### DIFF
--- a/lib/elastic.js
+++ b/lib/elastic.js
@@ -1,23 +1,19 @@
+const elasticsearch = require('@elastic/elasticsearch')
+const createAwsElasticsearchConnector = require('aws-elasticsearch-connector')
 const AWS = require('aws-sdk')
-const elasticsearch = require('elasticsearch')
+
 const credentials = require('./aws-credentials')
 
-// This should match the version of ELasticsearch used
-const API_VERSION = '5.6'
-
-const REGION = /\.(\w{2}-\w{4}-\d)\.es\./
+const REGION_REGEX = /\.(\w{2}-\w{4}-\d)\.es\./
 
 function createClient (url) {
   const local = url.includes('localhost')
-  const region = local ? undefined : url.match(REGION).pop()
+  const region = local ? undefined : url.match(REGION_REGEX).pop()
   const awsConfig = local ? undefined : new AWS.Config({ region, credentials })
-  const connectionClass = local ? undefined : require('http-aws-es')
 
   const client = new elasticsearch.Client({
-    connectionClass,
-    awsConfig,
-    host: url,
-    apiVersion: API_VERSION
+    ...createAwsElasticsearchConnector(awsConfig),
+    node: url
   })
 
   // expose the AWS host details

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@financial-times/n-es-tools",
   "version": "0.0.0",
   "dependencies": {
+    "@elastic/elasticsearch": "~7.9.0",
     "async-sema": "^3.0.0",
+    "aws-elasticsearch-connector": "^9.0.3",
     "aws-sdk": "^2.124.0",
     "chalk": "^2.3.0",
     "commander": "^3.0.0",
-    "elasticsearch": "^16.0.0",
     "http-aws-es": "^4.0.0",
     "js-yaml": "^3.10.0",
     "mkdirp": "^0.5.1",

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -7,9 +7,9 @@ auth:
 
 # Paths to the Elasticsearch clusters to be managed
 clusters:
-  eu: {{ELASTIC_SEARCH_HOST_EU}}
-  us: {{ELASTIC_SEARCH_HOST_US}}
-  dev: {{ELASTIC_SEARCH_HOST_DEV}}
+  eu: {{ELASTICSEARCH_V7_HOST_EU}}
+  us: {{ELASTICSEARCH_V7_HOST_US}}
+  dev: {{ELASTICSEARCH_V7_HOST_DEV}}
   local: http://localhost:9200
 
 # API keys

--- a/tools/repository.js
+++ b/tools/repository.js
@@ -24,7 +24,7 @@ function run (cluster, command) {
   client = elastic(cluster)
 
   if (!opts.bucketName) {
-    opts.bucketName = `next-elasticsearch-${client.host.region}-backups`
+    opts.bucketName = `next-elasticsearch-v7-${client.host.region}-backups`
   }
 
   return createRepository(opts)


### PR DESCRIPTION
This PR updates the repo to point to the new Elasticsearch v7 cluster.

The upgrade requires that the Elasticsearch client consumed from the npm registry is updated from `elasticsearch` to `@elastic/elasticsearch`. Details on the changes relating to this can be seen in the description of this PR: https://github.com/Financial-Times/next-es-interface/pull/1556.

#### TODO
- [x] Keys added to Vault: `ELASTICSEARCH_V7_HOST_EU`, `ELASTICSEARCH_V7_HOST_US`, `ELASTICSEARCH_V7_HOST_DEV`

#### References:
- [npm registry: `elasticsearch`](https://www.npmjs.com/package/elasticsearch)
- [npm registry: `@elastic/elasticsearch`](https://www.npmjs.com/package/@elastic/elasticsearch)

#### New dependencies:
- [npm registry: `@elastic/elasticsearch`](https://www.npmjs.com/package/@elastic/elasticsearch)
- [npm registry: `aws-elasticsearch-connector`](https://www.npmjs.com/package/aws-elasticsearch-connector)