### PR TITLE
Update response to use body object per es7 migration

### DIFF
--- a/tools/uuids.js
+++ b/tools/uuids.js
@@ -20,10 +20,10 @@ function fetchScan () {
     _source: false
   })
     .then((response) => {
-      status.total = response.hits.total
+      status.total = response.body.hits.total
 
-      response.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
-      status.tick(response.hits.hits.length)
+      response.body.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
+      status.tick(response.body.hits.hits.length)
 
       return response._scroll_id
     })
@@ -35,10 +35,10 @@ function fetchScroll (scrollId) {
     scrollId
   })
     .then((response) => {
-      response.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
-      status.tick(response.hits.hits.length)
+      response.body.hits.hits.forEach((item, i) => output.write(item._id + '\n'))
+      status.tick(response.body.hits.hits.length)
 
-      if (response.hits.hits.length > 0) {
+      if (response.body.hits.hits.length > 0) {
         return fetchScroll(response._scroll_id)
       } else {
         output.end()


### PR DESCRIPTION
`n-es-tools` was migrated to v7 of Elastic Search in this PR: https://github.com/Financial-Times/n-es-tools/pull/87

@AliceArmstrong and I have since tried to use `n-es-tools` in reindexing Elastic Search, per the instructions in [the wiki guide to reindexing with n-es-tools](https://github.com/Financial-Times/next-es-interface/wiki/Updating-index-mappings#guide-to-reindexing-with-n-es-tools-and-postman) and have run into errors when running the `n-es-tools uuids us` command.

I have made some progress towards a fix, but the command is still not running successfully.

I have updated the scroll function to inspect the `response.body` rather than just the `response` as this is a schema change that has been introduced in es7 - see, for example, this similar PR from @andygout - https://github.com/Financial-Times/next-es-interface/pull/1586.

The command is still not running successfully and is now returning 
```
UUIDs failed: RangeError: Invalid array length
```
That [error is thrown here](https://github.com/Financial-Times/n-es-tools/blob/main/tools/uuids.js#L74) but I have not got further than that and will now have to put this down.


