### PR TITLE
Add command for list indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 Thumbs.db
 npm-debug.log
 uuids-*.txt
+*.env*

--- a/bin/tools
+++ b/bin/tools
@@ -23,6 +23,7 @@ const tools = [
   'diff',
   'ingest',
   'install',
+  'list-indices',
   'reindex',
   'repository',
   'restore',

--- a/tools/list-indices.js
+++ b/tools/list-indices.js
@@ -1,0 +1,38 @@
+const elastic = require('../lib/elastic')
+
+let client
+
+function fetchIndices () {
+  return client.cat.indices({
+    format: 'json'
+  })
+}
+
+async function run (cluster) {
+  client = elastic(cluster)
+  const clusterHost = global.workspace.clusters[cluster]
+
+  console.log(`Listing all indices in ${clusterHost}`)
+
+  try {
+    const elasticsearchResponse = await fetchIndices()
+    const output = elasticsearchResponse.body.map(item => {
+      return {
+        indexName: item.index,
+        documentCount: item['docs.count']
+      }
+    })
+
+    console.log(output)
+  } catch (error) {
+    console.log(`Failed to get indices for ${clusterHost}`)
+    console.log(error.message)
+  }
+}
+
+module.exports = function (program) {
+  program
+    .command('list-indices <cluster>')
+    .description('List all of the indices within the cluster - clusters options include dev,eu,us')
+    .action(run)
+}


### PR DESCRIPTION
**What**
Adds a new tool that allows us to list out the indices within a cluster.

**Why**
The hope is that this tool will be helpful when performing a reindex of the clusters and replace the existing postman collections / documentation.

**Example usage**
`n-es-tools list-indices {cluster}`

**Example output**
```js
Listing all indices in {clusterHost}
[
  { indexName: 'content_2021-01-27', documentCount: '12227527' },
  { indexName: '.kibana_1', documentCount: '1' },
  { indexName: '.tasks', documentCount: '97666' }
]
```