### PR TITLE
Add command for delete-index

### DIFF
--- a/bin/tools
+++ b/bin/tools
@@ -21,6 +21,7 @@ if (fs.existsSync(configPath)) {
 const tools = [
   'alias',
   'diff',
+  'delete-index',
   'ingest',
   'install',
   'reindex',

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -8,7 +8,7 @@ function run (cluster, command) {
 
   console.log(`Deleting index ${indexName} from ${cluster}: ${clusterHost}`)
 
-  client.delete({
+  client.indices.delete({
     format: 'json',
     index: indexName
   })

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -1,0 +1,30 @@
+const elastic = require('../lib/elastic')
+
+function run (cluster, command) {
+  const client = elastic(cluster)
+  const clusterHost = global.workspace.clusters[cluster]
+  const options = command.opts()
+  const indexName = options.index
+
+  console.log(`Deleting index ${indexName} from ${cluster}: ${clusterHost}`)
+
+  client.delete({
+    format: 'json',
+    index: indexName
+  })
+    .then(() => {
+      console.log(`Index ${indexName} has been deleted from ${cluster}: ${clusterHost}`)
+    })
+    .catch(error => {
+      console.log(`Failed to delete ${indexName} from ${cluster}: ${clusterHost}`)
+      console.log(error.message)
+    })
+}
+
+module.exports = function (program) {
+  program
+    .command('delete-index <cluster>')
+    .description('delete a given index within a cluster - clusters options include dev,eu,us')
+    .option('-I, --index <name>', 'The index name')
+    .action(run)
+}


### PR DESCRIPTION
We are working on making the reindexing of ES more robust by moving the postman collection contained in the instructions in the existing wiki guide to a set of commands in next-es-tools. Step one is to recreate the calls in the postman collection as is, and step two is to refine them to make the process more robust by adding prompting and messaging to the user about the steps they are taking.

This PR recreates the 'delete an index' postman call (step one), but does not introduce additional guardrails for the user (step 2)