### PR TITLE
Add command for create indices

### DIFF
--- a/bin/tools
+++ b/bin/tools
@@ -20,6 +20,7 @@ if (fs.existsSync(configPath)) {
 // register all tools
 const tools = [
   'alias',
+  'create-index',
   'diff',
   'ingest',
   'install',

--- a/tools/create-index.js
+++ b/tools/create-index.js
@@ -1,0 +1,58 @@
+const os = require('os')
+const path = require('path')
+const fileSystem = require('fs')
+const elastic = require('../lib/elastic')
+
+function loadIndexSchema () {
+  const schemaPath = path.join(os.homedir(), '.n-es-tools', 'index-schema.json')
+  return fileSystem.readFileSync(schemaPath, 'utf8')
+}
+
+let client
+
+function createIndex (indexName, indexSchema) {
+  return client.indices.create({
+    index: indexName,
+    body: indexSchema
+  })
+}
+
+async function run (cluster, command) {
+  const clusterHost = global.workspace.clusters[cluster]
+  const options = command.opts()
+  const indexName = options.index
+  let indexSchema
+  client = elastic(cluster)
+
+  if (!indexName) {
+    throw new Error('The --index option is required')
+  }
+
+  console.log(`You are about to create a new index in ${clusterHost}`)
+
+  console.log(`The new index will be called ${options.index}`)
+
+  try {
+    indexSchema = loadIndexSchema()
+  } catch (error) {
+    console.log('Failed to load index schema', error.message)
+  }
+
+  try {
+    await createIndex(indexName, indexSchema)
+
+    console.log('New index created')
+    console.log(`Created in: ${clusterHost}`)
+    console.log(`New index called: ${indexName}`)
+  } catch (error) {
+    console.log('Failed to create index', error.meta.statusCode, error.meta.body.Message)
+  }
+}
+
+module.exports = function (program) {
+  program
+    .command('create-index <cluster>')
+    .description('Creates a new index within the cluster - clusters options include dev,eu,us')
+    .option('-I, --index <name>', 'The index name you want to create')
+    .action(run)
+}


### PR DESCRIPTION
**What**
Adds a new tool that allows us to create a new index within a cluster

**Why**
The hope is that this tool will be helpful when performing a reindex of the clusters and replace the existing postman collections / documentation

**Example usage**

`n-es-tools create-indices {cluster} --index {index-name}`

This also relies on a index-schema.json file living within the .n-es-tools directory in your home directory. eg. `~/.n-es-tools/index-schema.json`

The contents of that file should come from the latest version of [this file](https://github.com/Financial-Times/next-es-interface/blob/main/schema/content.json)