### PR TITLE
Create reassign alias command

### DIFF
--- a/bin/tools
+++ b/bin/tools
@@ -26,6 +26,7 @@ const tools = [
   'reindex',
   'repository',
   'restore',
+  'reassign-alias',
   'snapshot',
   'snapshot-download',
   'sync',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "scripts": {
     "postinstall": "node bin/tools install",
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine",
+    "precommit": "secret-squirrel",
+    "commitmsg": "secret-squirrel-commitmsg",
+    "prepush": "make verify -j3"
   },
   "bin": {
     "n-es-tools": "bin/tools"

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -21,7 +21,7 @@ function run (cluster, command) {
     })
     .catch(error => {
       console.log(`Failed to delete ${indexName} from ${cluster}: ${clusterHost}`)
-      console.log(error.message)
+      console.log('error: ', error.meta.statusCode, error.meta.body.Message)
     })
 }
 

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -2,11 +2,11 @@ const elastic = require('../lib/elastic')
 
 function run (cluster, command) {
   const { indexName } = command.opts()
-  
-  if(!indexName) {
+
+  if (!indexName) {
     console.log(`You have not provided a value for 'index'. Please provide a value for 'index' with the --index option before continuing`)
   }
-  
+
   const client = elastic(cluster)
   const clusterHost = global.workspace.clusters[cluster]
 

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -1,10 +1,14 @@
 const elastic = require('../lib/elastic')
 
 function run (cluster, command) {
+  const { indexName } = command.opts()
+  
+  if(!indexName) {
+    console.log(`You have not provided a value for 'index'. Please provide a value for 'index' with the --index option before continuing`)
+  }
+  
   const client = elastic(cluster)
   const clusterHost = global.workspace.clusters[cluster]
-  const options = command.opts()
-  const indexName = options.index
 
   console.log(`Deleting index ${indexName} from ${cluster}: ${clusterHost}`)
 

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -29,7 +29,7 @@ function run (cluster, command) {
     ]
   }
 
-  client.indices.updateAliases({ body: { actions } })
+  return client.indices.updateAliases({ body: { actions } })
     .then(() => {
       console.log(`Successfully reassigned alias ${alias} from ${oldIndex} to ${newIndex} in ${cluster}: ${clusterHost}`)
     })

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -1,7 +1,7 @@
 const elastic = require('../lib/elastic')
 
 function createErrorMessage (value) {
-  console.log(`You have not provided a value for ${value}. Please provide a value for ${value} with the --${value} option before continuing`)
+  return console.log(`You have not provided a value for ${value}. Please provide a value for ${value} with the --${value} option before continuing`)
 }
 
 function run (cluster, command) {

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -1,0 +1,43 @@
+const elastic = require('../lib/elastic')
+
+function displayErrorMessage (value) {
+  console.log(`You have not provided a value for ${value}. Please provide a value for ${value} with the --${value} option before continuing`)
+}
+
+function run (cluster, command) {
+  const { alias, oldIndex, newIndex } = command.opts()
+
+  if (!alias) {
+    displayErrorMessage('alias')
+  }
+  if (!oldIndex) {
+    displayErrorMessage('oldIndex')
+  }
+  if (!newIndex) {
+    displayErrorMessage('newIndex')
+  }
+
+  const client = elastic(cluster)
+  const clusterHost = global.workspace.clusters[cluster]
+
+  console.log(`Reassigning alias ${alias} from ${oldIndex} to ${newIndex} in ${cluster}: ${clusterHost}`)
+
+  const actions = {
+    'actions': [
+      { 'remove': { 'index': `${oldIndex}`, 'alias': `${alias}` } },
+      { 'add': { 'index': `${newIndex}`, 'alias': `${alias}` } }
+    ]
+  }
+
+  return client.indices.updateAliases({ body: { actions } })
+}
+
+module.exports = function (program) {
+  program
+    .command('assign-alias <cluster>')
+    .description('reassigns an alias from one index to another')
+    .option('-A, --alias', 'name of the alias to reassign')
+    .option('-O, --oldIndex <name>', 'The old index name')
+    .option('-N, --newIndex <name>', 'The new index name')
+    .action(run)
+}

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -1,7 +1,7 @@
 const elastic = require('../lib/elastic')
 
 function createErrorMessage (value) {
-  return console.log(`You have not provided a value for ${value}. Please provide a value for ${value} with the --${value} option before continuing`)
+  return `You have not provided a value for ${value}. Please provide a value for ${value} with the --${value} option before continuing`
 }
 
 function run (cluster, command) {


### PR DESCRIPTION
**What**
A simpler version of the `alias` command, which reassigns an alias from one cluster to another. This command requires the user to provide alias, old index, and new index values. This removes some of the 'magic' from the existing command which works automatically without any input values.

**Why**
The hope is that this tool will be helpful when performing a reindex of the clusters and replace the existing postman collections / documentation

**Example usage**

n-es-tools assign-alias {cluster} --alias {alias-name} --oldIndex {index-name} --oldIndex {index-name}

-------

Question: Do we want to delete the existing command? (https://github.com/Financial-Times/n-es-tools/blob/main/tools/alias.js)

This PR also adds error handling to the delete-index command