### PR TITLE
Standardise error logging

### DIFF
--- a/tools/create-index.js
+++ b/tools/create-index.js
@@ -48,7 +48,10 @@ async function run (cluster, command) {
     console.log(`${chalk.green('Created in:')} ${clusterHost}`)
     console.log(`${chalk.green('New index called:')} ${indexName}`)
   } catch (error) {
-    console.log(chalk.red.bold.underline('Failed to create index'), error.meta.statusCode, error.meta.body.Message)
+    console.log(chalk.red.bold.underline('Failed to create index'))
+    console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
+    console.log(chalk.red('Error: '), error)
+    process.exit(1)
   }
 }
 

--- a/tools/delete-index.js
+++ b/tools/delete-index.js
@@ -30,8 +30,8 @@ function run (cluster, command) {
       console.log(chalk.red.bold.underline('Failed to delete index'))
       console.log(`${chalk.red('Index:')} ${index}`)
       console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
-
-      console.log(chalk.red('Error: '), error.meta.statusCode, error.meta.body.Message)
+      console.log(chalk.red('Error: '), error)
+      process.exit(1)
     })
 }
 

--- a/tools/get-aliases.js
+++ b/tools/get-aliases.js
@@ -28,7 +28,7 @@ async function run (cluster, command) {
     .catch(error => {
       console.log(chalk.red.bold.underline('Failed to get aliases'))
       console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
-      console.log(error)
+      console.log(chalk.red('Error: '), error)
       process.exit(1)
     })
 }

--- a/tools/get-aliases.js
+++ b/tools/get-aliases.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const elastic = require('../lib/elastic')
 
 let client
@@ -10,14 +11,26 @@ function fetchAliases () {
 
 async function run (cluster, command) {
   client = elastic(cluster)
+  const clusterHost = global.workspace.clusters[cluster]
 
-  try {
-    const aliases = await fetchAliases()
-    console.log('aliases', aliases)
-  } catch (error) {
-    console.error(`get-alias failed: ${error}`)
-    process.exit(1)
-  }
+  return fetchAliases()
+    .then(response => {
+      const output = response.body.map(item => {
+        return {
+          indexName: item.index,
+          alias: item.alias
+        }
+      })
+
+      console.log(chalk.green.bold.underline('Aliases'))
+      console.log(output)
+    })
+    .catch(error => {
+      console.log(chalk.red.bold.underline('Failed to get aliases'))
+      console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
+      console.log(error)
+      process.exit(1)
+    })
 }
 
 module.exports = function (program) {

--- a/tools/list-indices.js
+++ b/tools/list-indices.js
@@ -30,7 +30,8 @@ async function run (cluster) {
   } catch (error) {
     console.log(chalk.red.bold.underline('Failed to get indices'))
     console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
-    console.log(error.message)
+    console.log(chalk.red('Error: '), error)
+    process.exit(1)
   }
 }
 

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -44,14 +44,12 @@ function run (cluster, command) {
     })
     .catch(error => {
       console.log(chalk.red.bold.underline('Failed to reassign alias'))
-
       console.log(`${chalk.red('Alias:')} ${aliasName}`)
       console.log(`${chalk.red('From Index:')} ${source}`)
       console.log(`${chalk.red('To Index:')} ${dest}`)
       console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
-
-      console.log(chalk.red('Error:'), error.meta.statusCode, error.meta.body.Message)
-      console.log(error)
+      console.log(chalk.red('Error: '), error)
+      process.exit(1)
     })
 }
 

--- a/tools/reassign-alias.js
+++ b/tools/reassign-alias.js
@@ -6,16 +6,16 @@ function createErrorMessage (value) {
 }
 
 function run (cluster, command) {
-  const { aliasName, oldIndex, newIndex } = command.opts()
+  const { aliasName, source, dest } = command.opts()
 
   if (!aliasName) {
     throw new Error(createErrorMessage('alias'))
   }
-  if (!oldIndex) {
-    throw new Error(createErrorMessage('oldIndex'))
+  if (!source) {
+    throw new Error(createErrorMessage('source'))
   }
-  if (!newIndex) {
-    throw new Error(createErrorMessage('newIndex'))
+  if (!dest) {
+    throw new Error(createErrorMessage('dest'))
   }
 
   const client = elastic(cluster)
@@ -23,14 +23,14 @@ function run (cluster, command) {
 
   console.log(chalk.cyan.bold.underline('Reassigning alias'))
   console.log(`${chalk.cyan('Alias:')} ${aliasName}`)
-  console.log(`${chalk.cyan('From Index:')} ${oldIndex}`)
-  console.log(`${chalk.cyan('To Index:')} ${newIndex}`)
+  console.log(`${chalk.cyan('From Index:')} ${source}`)
+  console.log(`${chalk.cyan('To Index:')} ${dest}`)
   console.log(`${chalk.cyan('Cluster:')} ${cluster}: ${clusterHost}`)
 
   const actions = {
     'actions': [
-      { 'remove': { 'index': `${oldIndex}`, 'alias': `${aliasName}` } },
-      { 'add': { 'index': `${newIndex}`, 'alias': `${aliasName}` } }
+      { 'remove': { 'index': `${source}`, 'alias': `${aliasName}` } },
+      { 'add': { 'index': `${dest}`, 'alias': `${aliasName}` } }
     ]
   }
 
@@ -38,16 +38,16 @@ function run (cluster, command) {
     .then(() => {
       console.log(chalk.green.bold.underline('Alias reassigned'))
       console.log(`${chalk.green('Alias:')} ${aliasName}`)
-      console.log(`${chalk.green('From Index:')} ${oldIndex}`)
-      console.log(`${chalk.green('To Index:')} ${newIndex}`)
+      console.log(`${chalk.green('From Index:')} ${source}`)
+      console.log(`${chalk.green('To Index:')} ${dest}`)
       console.log(`${chalk.green('Cluster:')} ${cluster}: ${clusterHost}`)
     })
     .catch(error => {
       console.log(chalk.red.bold.underline('Failed to reassign alias'))
 
       console.log(`${chalk.red('Alias:')} ${aliasName}`)
-      console.log(`${chalk.red('From Index:')} ${oldIndex}`)
-      console.log(`${chalk.red('To Index:')} ${newIndex}`)
+      console.log(`${chalk.red('From Index:')} ${source}`)
+      console.log(`${chalk.red('To Index:')} ${dest}`)
       console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
 
       console.log(chalk.red('Error:'), error.meta.statusCode, error.meta.body.Message)
@@ -60,7 +60,7 @@ module.exports = function (program) {
     .command('reassign-alias <cluster>')
     .description('reassigns an alias from one index to another')
     .option('-A, --aliasName <name>', 'name of the alias to reassign')
-    .option('-O, --oldIndex <name>', 'The old index name')
-    .option('-N, --newIndex <name>', 'The new index name')
+    .option('-S, --source <name>', 'The old index name')
+    .option('-D, --dest <name>', 'The new index name')
     .action(run)
 }

--- a/tools/reindex.js
+++ b/tools/reindex.js
@@ -94,8 +94,12 @@ function run (cluster, command) {
       console.log(`Reindex from ${opts.source} to ${opts.dest} complete`)
       process.exit()
     })
-    .catch((err) => {
-      console.error(`Reindex failed: ${err.toString()}`)
+    .catch((error) => {
+      console.log(chalk.red.bold.underline('Failed to reindex'))
+      console.log(`${chalk.red('From Index:')} ${opts.source}`)
+      console.log(`${chalk.red('To Index:')} ${opts.dest}`)
+      console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
+      console.log(chalk.red('Error: '), error)
       process.exit(1)
     })
 }

--- a/tools/uuids.js
+++ b/tools/uuids.js
@@ -3,6 +3,7 @@ const elastic = require('../lib/elastic')
 const progress = require('../lib/progress')
 const template = require('../lib/template')
 const resolvePath = require('../lib/resolve-path')
+const chalk = require('chalk')
 
 let client
 let status
@@ -50,6 +51,7 @@ function run (cluster, command) {
   client = elastic(cluster)
   status = progress('Downloading UUIDs')
   options = command.opts()
+  const clusterHost = global.workspace.clusters[cluster]
 
   // allow templating in filename to interpolate options ✌️
   const filename = template(options.filename, Object.assign({}, options, { cluster }))
@@ -70,8 +72,10 @@ function run (cluster, command) {
       console.log(`UUIDs saved to ${filepath}`)
       process.exit()
     })
-    .catch((err) => {
-      console.error(`UUIDs failed: ${err.toString()}`)
+    .catch((error) => {
+      console.log(chalk.red.bold.underline('Failed to write UUIDs'))
+      console.log(`${chalk.red('Cluster:')} ${cluster}: ${clusterHost}`)
+      console.log(chalk.red('Error: '), error)
       process.exit(1)
     })
 }


### PR DESCRIPTION
Standardise error logging across new commands:
- Use the same messaging and format for each
- Log the full error as trying to extract the useful bits wasn't actually useful
- Exit the process after error logging complete

Merge #111 first as this PR is a branch off that. This commit is the only new change introduced in this PR - https://github.com/Financial-Times/n-es-tools/commit/69896381fd5c7d3dede3eaba183f9f3f0b34f4f3