### PR TITLE
Fix the reindex progress bar

### DIFF
--- a/tools/reindex.js
+++ b/tools/reindex.js
@@ -43,7 +43,7 @@ function pingStatus (taskId) {
     .then((result) => {
       const resBody = result.body
       status.total = resBody.task.status.total
-      status.curr = resBody.task.status.updated
+      status.curr = resBody.task.status.created
 
       // Don't draw a progress bar before we have any data
       // and don't draw one when AWS gets carried away.


### PR DESCRIPTION
When the new index is empty the updates we will get will be `created` rather than `updated`

This means this solution will only work for a brand new index with no content, however this is the majority of our cases so I think this is fine for now