### PR TITLE
Exit process when there is no index-schema.json file present when running create-index command

### DIFF
--- a/tools/create-index.js
+++ b/tools/create-index.js
@@ -39,6 +39,7 @@ async function run (cluster, command) {
     indexSchema = loadIndexSchema()
   } catch (error) {
     console.log(chalk.red.bold.underline('Failed to load index schema'), error.message)
+    process.exit(1)
   }
 
   try {


### PR DESCRIPTION
Currently the command continues to run even when there is no schema file present which we don't want